### PR TITLE
fix log list int value

### DIFF
--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -21,6 +21,7 @@ from .http_exception_handler import (http_message_exception_handler,
                                      http_message_429_exception_handler)
 from .kafka import kafka_consumer
 from .get_list_field import get_field_list
+from .convert_to_int import convert_to_int
 import logging
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(name)s - %(message)s")

--- a/app/core/convert_to_int.py
+++ b/app/core/convert_to_int.py
@@ -1,0 +1,5 @@
+def convert_to_int(val, default_val=0):
+  try:
+    return int(val)
+  except ValueError:
+    return default_val

--- a/app/services/log.py
+++ b/app/services/log.py
@@ -15,7 +15,7 @@ from ..models import (Log as ModelLog,
                       PredictedLog as ModelPredictedLog)
 from ..schemas import (LogFilter as SchemaLogFilter,
                        User as SchemaUser)
-from ..core import getenv, get_field_list
+from ..core import getenv, get_field_list, convert_to_int
 from ..enums.predicted_log_targets import PredictedLogTargets
 from ..enums.columns_log import ColumnsLog
 
@@ -213,9 +213,9 @@ def insert_log(db: Session, user_id: str, log: str) -> ModelLog:
       datetime=log_datetime,
       host=host,
       service=service,
-      pid=pid,
+      pid=convert_to_int(pid),
       message=message,
-      time_execution=time_execution,
+      time_execution=convert_to_int(time_execution),
       user_id=user_id
   )
 


### PR DESCRIPTION
Corrección de un bug que simplemente a la hora de insertar un log puede llegar el campo pid y el campo time_execution como un string, ya que en la tabla de la base de datos solo permite guardar INT. Lo que hecho básicamente es realizar una función que los convierta en INT y en caso de error que devuelva un numero por defecto en esta caso 0. 